### PR TITLE
Add Vive coding tool route

### DIFF
--- a/app/components/sidebar/Menu.client.tsx
+++ b/app/components/sidebar/Menu.client.tsx
@@ -117,6 +117,13 @@ export function Menu() {
             <span className="inline-block i-bolt:chat scale-110" />
             Start new chat
           </a>
+          <a
+            href="/vive"
+            className="flex gap-2 items-center bg-bolt-elements-sidebar-buttonBackgroundDefault text-bolt-elements-sidebar-buttonText hover:bg-bolt-elements-sidebar-buttonBackgroundHover rounded-md p-2 mt-2 transition-theme"
+          >
+            <span className="inline-block i-ph:code" />
+            Vive coding tool
+          </a>
         </div>
         <div className="text-bolt-elements-textPrimary font-medium pl-6 pr-5 my-2">Your Chats</div>
         <div className="flex-1 overflow-scroll pl-4 pr-5 pb-5">

--- a/app/routes/vive.tsx
+++ b/app/routes/vive.tsx
@@ -1,0 +1,23 @@
+import { json, type MetaFunction } from '@remix-run/cloudflare';
+import { ClientOnly } from 'remix-utils/client-only';
+import { BaseChat } from '~/components/chat/BaseChat';
+import { Chat } from '~/components/chat/Chat.client';
+import { Header } from '~/components/header/Header';
+
+export const meta: MetaFunction = () => {
+  return [
+    { title: 'Vive Coding Tool' },
+    { name: 'description', content: 'Experiment with the Vive coding tool' },
+  ];
+};
+
+export const loader = () => json({});
+
+export default function Vive() {
+  return (
+    <div className="flex flex-col h-full w-full">
+      <Header />
+      <ClientOnly fallback={<BaseChat />}>{() => <Chat />}</ClientOnly>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add /vive route for Vive Coding Tool
- link to Vive Coding Tool in sidebar menu

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_b_685b4b2a2f70832da24f99ad98c2d65d